### PR TITLE
gdb server: Add back support to disable the gdb server via the gdb_port config

### DIFF
--- a/src/server/gdb_server.c
+++ b/src/server/gdb_server.c
@@ -2920,6 +2920,11 @@ static int gdb_target_start(struct target *target, const char *port)
 
 static int gdb_target_add_one(struct target *target)
 {
+	if (strcmp(gdb_port, "disabled") == 0) {
+		LOG_INFO("gdb port disabled");
+		return ERROR_OK;
+	}
+
 	/*  one gdb instance per smp list */
 	if ((target->smp) && (target->gdb_service))
 		return ERROR_OK;
@@ -3108,7 +3113,7 @@ static const struct command_registration gdb_command_handlers[] = {
 			"server listens for the next port number after the "
 			"base port number specified. "
 			"No arguments reports GDB port. \"pipe\" means listen to stdin "
-			"output to stdout, an integer is base port number, \"disable\" disables "
+			"output to stdout, an integer is base port number, \"disabled\" disables "
 			"port. Any other string is are interpreted as named pipe to listen to. "
 			"Output pipe is the same name as input pipe, but with 'o' appended.",
 		.usage = "[port_num]",


### PR DESCRIPTION
As per the documentation, used "disabled" as the value to disable, as this is the same value to disable the telnet and tcl server.

Related to https://github.com/arduino/Arduino/issues/4330.

Also, submitted upstream (but no activity): http://openocd.zylin.com/#/c/3175/
